### PR TITLE
Add explicit dependency on lwt.tracing to _oasis

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -10,4 +10,4 @@ Library "mirage-profile"
   Path:       lib
   BuildTools: ocamlbuild
   Modules:    Profile
-  BuildDepends: sexplib,sexplib.syntax,lwt
+  BuildDepends: sexplib,sexplib.syntax,lwt,lwt.tracing


### PR DESCRIPTION
I had to add an explicit dependency on lwt.tracing and regenerate buildfiles with `oasis setup` to get a working build.
