### PR TITLE
Add labelled mvars

### DIFF
--- a/lib/trace_enabled.ml
+++ b/lib/trace_enabled.ml
@@ -340,3 +340,9 @@ let named_task label =
   | None -> ()
   | Some log -> Control.note_label log (Lwt.id_of_thread (fst pair)) label end;
   pair
+
+let named_mvar label v =
+  Lwt_mvar.create ~label v
+
+let named_mvar_empty label =
+  Lwt_mvar.create_empty ~label ()

--- a/lib/trace_stubs.ml
+++ b/lib/trace_stubs.ml
@@ -14,5 +14,7 @@ let label _label = ()
 let named_wait _label = Lwt.wait ()
 let named_task _label = Lwt.task ()
 let named_condition _label = Lwt_condition.create ()
+let named_mvar _label v = Lwt_mvar.create v
+let named_mvar_empty _label = Lwt_mvar.create_empty ()
 
 let note_increase _counter _amount = ()

--- a/lib/trace_stubs.mli
+++ b/lib/trace_stubs.mli
@@ -20,6 +20,12 @@ val named_task : string -> 'a Lwt.t * 'a Lwt.u
 val named_condition : string -> 'a Lwt_condition.t
 (** Create a Lwt_condition that will label its thread with the given name. *)
 
+val named_mvar_empty : string -> 'a Lwt_mvar.t
+(** Create a Lwt_mvar that will label its threads with the given name. *)
+
+val named_mvar : string -> 'a -> 'a Lwt_mvar.t
+(** Create a Lwt_mvar that will label its threads with the given name. *)
+
 val note_increase : string -> int -> unit
 (** [incr name amount] increases the named counter.
  * Deprecated: used Counter.increase instead. *)


### PR DESCRIPTION
This is useful for mirage-tcp, which creates several mvars per TCP connection.
