### PR TITLE
Use a monotonic clock on OS X

### DIFF
--- a/unix/time_stubs.c
+++ b/unix/time_stubs.c
@@ -6,18 +6,31 @@
 #include <caml/fail.h>
 #include <caml/bigarray.h>
 
+#ifdef __MACH__
+/* http://stackoverflow.com/questions/11680461/monotonic-clock-on-osx */
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 /* Write the current time to bigarray[idx] as a little-endian uint64 (nanoseconds). */
 CAMLprim value stub_mprof_get_monotonic_time(value bigarray, value index)
 {
 	uint64_t t;
-	struct timespec tv;
 	long idx = Long_val(index);
 	char *buffer = Data_bigarray_val(bigarray);
 	int buffer_len = Bigarray_val(bigarray)->dim[0];
+#ifdef __MACH__
+	clock_serv_t cclock;
+	mach_timespec_t tv;
 
+	host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+	clock_get_time(cclock, &tv);
+	mach_port_deallocate(mach_task_self(), cclock);
+#else
+	struct timespec tv;
 	clock_gettime(CLOCK_MONOTONIC, &tv);
+#endif
 	t = ((uint64_t) tv.tv_sec) * 1000000000 + tv.tv_nsec;
-
 	if (idx < 0 || idx + 7 >= buffer_len) caml_array_bound_error();
 
 	buffer[idx] = t & 0xff;


### PR DESCRIPTION
OS X doesn't have clock_gettime so we use something OS X-specific.
The clock_get_time is documented as monotonically increasing and the
clock_set_time function (which could screw that up) always returns
a KERN_FAILURE:

https://opensource.apple.com/source/xnu/xnu-2422.1.72/osfmk/kern/clock_oldops.c

Note the alternative AbsoluteTime API documented here

http://developer.apple.com/library/mac/qa/qa1398/

has been deprecated since 10.8.

Signed-off-by: David Scott dave.scott@citrix.com
