### PR TITLE
Add signal support

### DIFF
--- a/lib/trace_enabled.ml
+++ b/lib/trace_enabled.ml
@@ -135,6 +135,7 @@ module Control = struct
   let op_increase = 6
   let op_switch = 7
   let op_gc = 8
+  let op_signal = 9
 
   let write64 log v i =
     EndianBigstring.LittleEndian.set_int64 log i v;
@@ -207,6 +208,13 @@ module Control = struct
       |> write64 log.log input
       |> end_event
     )
+
+  let note_signal log source =
+    current_thread := Lwt.current_id ();
+    add_event log op_signal 16
+    |> write64 log.log !current_thread
+    |> write64 log.log source
+    |> end_event
 
   let note_resolved log p ~ex =
     match ex with
@@ -293,6 +301,7 @@ module Control = struct
       note_created = note_created log;
       note_read = note_read log;
       note_resolved = note_resolved log;
+      note_signal = note_signal log;
       note_becomes = note_becomes log;
       note_label = note_label log;
       note_switch = note_switch log;

--- a/metadata
+++ b/metadata
@@ -39,7 +39,8 @@ struct event_header {
 		label = 5,
 		increase = 6,
 		switch = 7,
-		gc = 8
+		gc = 8,
+		signal = 9,
 	} id;
 } align (8);
 
@@ -136,3 +137,13 @@ event {
 		uint64_t duration_ns;
 	};
 };
+
+event {
+	name = signal;
+	id = 9;
+	context := struct thread_context;
+	fields := struct {
+		uint64_t source;
+	};
+};
+


### PR DESCRIPTION
Signals can be used to indicate interactions between threads that aren't reading or setting the result.
