### PR TITLE
Prepare to release 0.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,3 @@
+0.7.0 (2016-03-13)
+- depend on cstruct.ppx (from >= 1.9.0) rather than cstruct.syntax
+- improve usage instructions

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        mirage-profile
-Version:     0.6.1
+Version:     0.7.0
 Synopsis:    Record trace data
 Authors:     Thomas Leonard
 License:     BSD-2-clause

--- a/opam
+++ b/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 name: "mirage-profile"
-version: "0.6.1"
-available: [ ocaml-version >= "4.00" ]
+version: "0.7.0"
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"


### PR DESCRIPTION
- add CHANGES.md with single entry
- bump version in _oasis and opam
- remove duplicated `available` section in `opam`: ppx requires
  ocaml >= 4.02.0

Signed-off-by: David Scott <dave.scott@docker.com>