### PR TITLE
Fix linking problem on Ubuntu 12.04

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -634,9 +634,11 @@ let dispatch_default = MyOCamlbuildBase.dispatch_default conf package_default;;
 (* OASIS_STOP *)
 
 (* Copied from mtime *)
+(* The "--no-as-needed" thing seems to be required on Ubuntu 12.04.
+   See: https://github.com/mirage/mirage-skeleton/pull/135 *)
 let os = Ocamlbuild_pack.My_unix.run_and_read "uname -s"
 let system_support_lib = match os with
-| "Linux\n" -> [A "-cclib"; A "-lrt"]
+| "Linux\n" -> [A "-cclib"; A "-Wl,--no-as-needed"; A "-cclib"; A "-lrt"]
 | _ -> []
 
 let () =


### PR DESCRIPTION
Error was:

    /root/.opam/system/lib/mirage-profile/libmProf_unix_stubs.a(time_stubs.o):
In function `stub_mprof_get_monotonic_time':
    /root/.opam/system/build/mirage-profile.0.7.0/_build/unix/time_stubs.c:31:
undefined reference to `clock_gettime'

Hopefully fixes https://github.com/mirage/mirage-skeleton/pull/135