### PR TITLE
Don't link client libraries against cstruct.ppx

### DIFF
--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ build: [[
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build}
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Record trace data"
-requires = "lwt ocplib-endian.bigstring cstruct cstruct.ppx"
+requires = "lwt ocplib-endian.bigstring cstruct"
 archive(byte) = "mProf.cma"
 plugin(byte) = "mProf.cma"
 archive(native) = "mProf.cmxa"


### PR DESCRIPTION
The cstruct.ppx library is a helper library for the PPX rewriter itself, and is not needed by the output of the rewriter. Unfortunately linking against cstruct.ppx also brings in compiler-libs which (apart from being big) also pollutes the global module name space since it defines modules like "Types".

See https://github.com/mirage/mirage-www/pull/556

Signed-off-by: David Scott <dave@recoil.org>