### PR TITLE
Update opam for 0.9.0 release.

### DIFF
--- a/mirage-profile-unix.opam
+++ b/mirage-profile-unix.opam
@@ -14,7 +14,6 @@ depends: [
   "ocplib-endian"
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-profile.git"

--- a/mirage-profile-xen.opam
+++ b/mirage-profile-xen.opam
@@ -18,7 +18,6 @@ depends: [
   "xenstore"
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-profile.git"

--- a/mirage-profile-xen.opam
+++ b/mirage-profile-xen.opam
@@ -14,7 +14,7 @@ depends: [
   "io-page"
   "mirage-xen-minios"
   "ocplib-endian"
-  "mirage-xen"
+  "mirage-xen" {>="3.3.0" & <"4.0.0"}
   "xenstore"
 ]
 build: [

--- a/mirage-profile.opam
+++ b/mirage-profile.opam
@@ -15,7 +15,6 @@ depends: [
   "lwt"
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-profile.git"


### PR DESCRIPTION
- Add constraint on mirage-xen
- Remove unused substs.