### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-profile-unix.opam
+++ b/mirage-profile-unix.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile/"
 bug-reports: "https://github.com/mirage/mirage-profile/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-profile" {>= "0.8.0"}
   "mtime" {>= "1.0.0"}
   "ocplib-endian"

--- a/mirage-profile-xen.opam
+++ b/mirage-profile-xen.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile/"
 bug-reports: "https://github.com/mirage/mirage-profile/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-profile" {=version}
   "io-page-xen"
   "io-page"

--- a/mirage-profile.opam
+++ b/mirage-profile.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile/"
 bug-reports: "https://github.com/mirage/mirage-profile/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_cstruct" {build}
   "ocplib-endian"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.