### PR TITLE
remove the ppx_cstruct usage

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -17,6 +17,4 @@
    (lwt.tracing -> mProf_with_tracing)
    (!lwt.tracing -> mProf_without_tracing)))
  (modules MProf MProf_trace MProf_counter)
- (wrapped false)
- (preprocess
-  (pps ppx_cstruct)))
+ (wrapped false))

--- a/mirage-profile.opam
+++ b/mirage-profile.opam
@@ -10,7 +10,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_cstruct" {build}
   "ocplib-endian"
   "lwt"
 ]


### PR DESCRIPTION
the underlying reason is to shave the dependency cone of our core libraries

ppx_cstruct requires sexplib which requires base.

I'm still wondering about #82 (is this library actively used and maintained? should it be removed from the dependency cone?)

any opinion @mirage/core?